### PR TITLE
fixing possible syntax bug with childNodes

### DIFF
--- a/ghost-footnote-helper.js
+++ b/ghost-footnote-helper.js
@@ -21,7 +21,7 @@ function walkTree (node) {
 			aElem.href = '#fnref-' + content;
 			aElem.className = fn_className;
 			aElem.innerText = fn_backSymbol;
-			footnotes[index].childNodes[0].appendChild(aElem);
+			footnotes[index].children[0].appendChild(aElem);
 			index = index + 1;
 		}
 	}


### PR DESCRIPTION
I tried to implement this code and was getting an error of "Failed to execute 'appendChild' on 'Node'"
By replacing the childNode property with the children property, I was able to successfully run the code.  Not sure if this is truly a bug fix or a workaround related to my own user error in implementing your code, but I thought I'd submit it if it helps make solution easier for others to implement.